### PR TITLE
fix: allow data uri as image src

### DIFF
--- a/src/Responder.js
+++ b/src/Responder.js
@@ -1040,7 +1040,7 @@ class Responder {
     _attachment (attachmentUrl, type, reusable = false) {
         let url = attachmentUrl;
 
-        if (!url.match(/^https?:\/\//)) {
+        if (!url.match(/^https?:\/\/|^data:/)) {
             url = `${this.options.appUrl}${url}`;
         }
 


### PR DESCRIPTION
when image response is used with data uri as src it has prepended another url which is wrong.

If possilble, creating backport into 3.10 version would by greatly appriciated.